### PR TITLE
Feat init project dry run

### DIFF
--- a/common/changes/rush-init-project-plugin/feat-init-project-dry-run_2024-03-25-22-38.json
+++ b/common/changes/rush-init-project-plugin/feat-init-project-dry-run_2024-03-25-22-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-init-project-plugin",
+      "comment": "Remove \"-d\" ambiguous parameter",
+      "type": "minor"
+    }
+  ],
+  "packageName": "rush-init-project-plugin"
+}

--- a/rush-plugins/rush-init-project-plugin/command-line.json
+++ b/rush-plugins/rush-init-project-plugin/command-line.json
@@ -22,7 +22,6 @@
     {
       "parameterKind": "flag",
       "description": "Provide the option isDryRun in plugin context",
-      "shortName": "-d",
       "longName": "--dry-run",
       "associatedCommands": ["init-project"],
       "required": false


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Remove ambiguous "-d" parameter for rush init-project.

### Detail

![img_v3_029b_f31d7fd5-0eab-4792-bb69-b1b56c52c6dh](https://github.com/tiktok/rush-plugins/assets/16147702/04f84c8a-ba6a-4298-8726-a247cad2806b)


### How to test it

Local
