### PR TITLE
fix: fix pattern match for path that contains dot

### DIFF
--- a/common/changes/rush-git-lfs-plugin/main_2024-06-13-03-59.json
+++ b/common/changes/rush-git-lfs-plugin/main_2024-06-13-03-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-git-lfs-plugin",
+      "comment": "fix pattern match for paths that contains dot.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-git-lfs-plugin"
+}

--- a/rush-plugins/rush-git-lfs-plugin/src/tests/executor/core.test.ts
+++ b/rush-plugins/rush-git-lfs-plugin/src/tests/executor/core.test.ts
@@ -8,9 +8,7 @@ describe('lfs file detect', () => {
     const tFile = factory.createTextFile('test-t');
     const checker = new GitLFSCheckModule();
     expect(checker.isFileNeedToTrack(bFile, { '**/*.png': 0, '**/*': 5 * 1024 * 1024 })).toBe(true);
-    expect(checker.isFileNeedToTrack(tFile, { '**/*.png': 0, '**/*': 5 * 1024 * 1024 })).toBe(
-      false
-    );
+    expect(checker.isFileNeedToTrack(tFile, { '**/*.png': 0, '**/*': 5 * 1024 * 1024 })).toBe(false);
   });
 
   it('should detect large file correctly', () => {
@@ -29,10 +27,14 @@ describe('lfs file detect', () => {
 
     const tsFile = factory.createSizedFile('tsFile.ts', 6 * 1024 * 1024);
     const jsFile = factory.createSizedFile('jsFile.js', 2 * 1024 * 1024);
+    //
+    const dotFile = factory.createSizedFile('.temp/a.js', 2 * 1024 * 1024);
+
     const checker = new GitLFSCheckModule();
 
     expect(checker.isFileNeedToTrack(tsFile, { '**/*.ts': 7 * 1024 * 1024 })).toBe(false);
     expect(checker.isFileNeedToTrack(jsFile, { '**/*.js': 1 * 1024 * 1024 })).toBe(true);
+    expect(checker.isFileNeedToTrack(dotFile, { '**/*.js': 1 * 1024 * 1024 })).toBe(true);
   });
 
   it('should detect LFS status correctly', () => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


### Summary

Fix glob pattern match for paths that contains dot.

### Detail

Add { dot: true } option to minimatch

### How to test it

- [x] Tested locally
- [x] Add a unit test case
