### PR TITLE
[rush-migrate-subspace-plugin]: add clean subspace feature

### DIFF
--- a/common/changes/rush-migrate-subspace-plugin/pedrogomes-support-clean-subspace_2024-12-20-04-18.json
+++ b/common/changes/rush-migrate-subspace-plugin/pedrogomes-support-clean-subspace_2024-12-20-04-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-migrate-subspace-plugin",
+      "comment": "Provides a parameter to automatically remove similar dependency versions, including duplicates and unused",
+      "type": "minor"
+    }
+  ],
+  "packageName": "rush-migrate-subspace-plugin"
+}

--- a/rush-plugins/rush-migrate-subspace-plugin/command-line.json
+++ b/rush-plugins/rush-migrate-subspace-plugin/command-line.json
@@ -28,6 +28,12 @@
       "longName": "--debug",
       "description": "Provide debug logs",
       "associatedCommands": ["migrate-subspace"]
+    },
+    {
+      "parameterKind": "flag",
+      "longName": "--clean",
+      "description": "Merge and clean multiple common versions together",
+      "associatedCommands": ["migrate-subspace"]
     }
   ]
 }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cleanSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cleanSubspace.ts
@@ -1,14 +1,244 @@
-import { chooseSubspacePrompt } from './prompts/subspace';
+import {
+  chooseSubspacePrompt,
+  scanForUnusedDependencyVersionsPrompt,
+  scanForDuplicatedDependenciesPrompt,
+  scanForSubsetDependencyVersionsPrompt,
+  scanForAllDependenciesPrompt
+} from './prompts/subspace';
 import Console from './providers/console';
 import { getRootPath } from './utilities/path';
 import { Colorize } from '@rushstack/terminal';
 import {
-  cleanSubspaceCommonVersions,
   getRushSubspaceCommonVersionsFilePath,
-  isSubspaceSupported
+  getSubspaceDependencies,
+  isSubspaceSupported,
+  loadRushSubspaceCommonVersions,
+  queryProjectsFromSubspace
 } from './utilities/subspace';
 import { getRushSubspacesConfigurationJsonPath, querySubspaces } from './utilities/repository';
 import { RushConstants } from '@rushstack/rush-sdk';
+import { chooseDependencyPrompt, confirmNextDependencyPrompt } from './prompts/dependency';
+import { IPackageJson, JsonFile } from '@rushstack/node-core-library';
+import { sortVersions, subsetVersion } from './utilities/dependency';
+import {
+  getProjectPackageFilePath,
+  loadProjectPackageJson,
+  updateProjectDependency
+} from './utilities/project';
+import { IRushConfigurationProjectJson } from '@rushstack/rush-sdk/lib/api/RushConfigurationProject';
+
+const removeSubsetDependency = async (
+  subspaceName: string,
+  dependencyName: string,
+  versionsMap: Map<string, string[]>,
+  rootPath: string = getRootPath()
+): Promise<number> => {
+  const versions: string[] = Array.from(versionsMap.keys());
+  const subspaceCommonVersionsPath: string = getRushSubspaceCommonVersionsFilePath(subspaceName, rootPath);
+  const subspaceCommonVersionsJson: RushSubspaceCommonVersionsJson = loadRushSubspaceCommonVersions(
+    subspaceName,
+    rootPath
+  );
+
+  const validVersions: string[] = sortVersions(versions);
+
+  let targetIndex: number = 0;
+  while (targetIndex < validVersions.length) {
+    const newVersion: string = validVersions[targetIndex];
+    const toCompareVersions: string[] = validVersions.slice(targetIndex + 1);
+
+    const toDeleteIndex: number = toCompareVersions.findIndex((toCompareVersion) =>
+      subsetVersion(toCompareVersion, newVersion)
+    );
+
+    if (toDeleteIndex > -1) {
+      // Delete subset version
+
+      const [deletedVersion] = validVersions.splice(targetIndex + 1 + toDeleteIndex, 1);
+      versionsMap.get(deletedVersion)?.forEach((projectName) => {
+        if (updateProjectDependency(projectName, dependencyName, newVersion, rootPath)) {
+          Console.debug(
+            `Updated project ${Colorize.bold(projectName)} for dependency ${Colorize.bold(
+              dependencyName
+            )} ${Colorize.bold(deletedVersion)} => ${Colorize.bold(newVersion)}!`
+          );
+        }
+      });
+    } else {
+      // Go to next version
+      targetIndex += 1;
+    }
+  }
+
+  const removedAlternativeVersionsCount: number = versions.length - validVersions.length;
+  if (removedAlternativeVersionsCount > 0) {
+    // Update subspace common versions
+    if (validVersions.length > 0) {
+      subspaceCommonVersionsJson.allowedAlternativeVersions![dependencyName] = validVersions;
+    } else {
+      delete subspaceCommonVersionsJson.allowedAlternativeVersions![dependencyName];
+    }
+
+    JsonFile.save(subspaceCommonVersionsJson, subspaceCommonVersionsPath);
+  }
+
+  return removedAlternativeVersionsCount;
+};
+
+const removeDuplicatedDependencies = (subspaceName: string, rootPath: string = getRootPath()): void => {
+  Console.log(`Removing duplicated dependencies for subspace ${Colorize.bold(subspaceName)}...`);
+
+  const projects: IRushConfigurationProjectJson[] = queryProjectsFromSubspace(subspaceName, rootPath);
+  let countRemoved: number = 0;
+  projects.forEach((project) => {
+    const projectPackageFilePath: string = getProjectPackageFilePath(project.projectFolder, rootPath);
+    const projectPackageJson: IPackageJson = loadProjectPackageJson(project.projectFolder, rootPath);
+
+    const dependencies: string[] = Object.keys(projectPackageJson.dependencies || {});
+    const devDependencies: string[] = Object.keys(projectPackageJson.devDependencies || {});
+
+    devDependencies.forEach((devDependency) => {
+      if (dependencies.includes(devDependency)) {
+        countRemoved += 1;
+        Console.debug(
+          `Removed ${Colorize.bold(devDependency)} from project ${Colorize.bold(project.packageName)}`
+        );
+        delete projectPackageJson.devDependencies![devDependency];
+      }
+    });
+
+    JsonFile.save(projectPackageJson, projectPackageFilePath);
+  });
+
+  if (countRemoved > 0) {
+    Console.success(
+      `Removed ${Colorize.bold(`${countRemoved}`)} duplicated dependencies from subspace ${Colorize.bold(
+        subspaceName
+      )}!`
+    );
+  } else {
+    Console.success(`No duplicated dependencies found for subspace ${Colorize.bold(subspaceName)}!`);
+  }
+};
+
+const removeUnusedAlternativeVersions = (
+  subspaceName: string,
+  subspaceDependencies: Map<string, Map<string, string[]>>
+): void => {
+  Console.log(`Removing unused alternative versions for subspace ${Colorize.bold(subspaceName)}...`);
+
+  const subspaceCommonVersionsPath: string = getRushSubspaceCommonVersionsFilePath(subspaceName);
+  const subspaceCommonVersionsJson: RushSubspaceCommonVersionsJson =
+    loadRushSubspaceCommonVersions(subspaceName);
+
+  if (!subspaceCommonVersionsJson.allowedAlternativeVersions) {
+    return;
+  }
+
+  let countRemoved: number = 0;
+
+  for (const [dependency, alternativeVersions] of Object.entries(
+    subspaceCommonVersionsJson.allowedAlternativeVersions
+  )) {
+    const subspaceDependency: Map<string, string[]> | undefined = subspaceDependencies.get(dependency);
+    const newAlternativeVersions: string[] =
+      subspaceDependency && subspaceDependency.size > 1
+        ? alternativeVersions.filter((version) => subspaceDependency.has(version))
+        : [];
+
+    const removedAlternativeVersionsCount: number =
+      alternativeVersions.length - newAlternativeVersions.length;
+    if (removedAlternativeVersionsCount > 0) {
+      countRemoved += removedAlternativeVersionsCount;
+      Console.debug(
+        `Moving from [${Colorize.bold(alternativeVersions.join(','))}] to [${Colorize.bold(
+          newAlternativeVersions.join(',')
+        )}] for dependency ${Colorize.bold(dependency)}`
+      );
+    }
+
+    if (newAlternativeVersions.length === 0) {
+      delete subspaceCommonVersionsJson.allowedAlternativeVersions[dependency];
+      continue;
+    }
+
+    subspaceCommonVersionsJson.allowedAlternativeVersions = {
+      ...subspaceCommonVersionsJson.allowedAlternativeVersions,
+      [dependency]: newAlternativeVersions
+    };
+  }
+
+  if (countRemoved > 0) {
+    JsonFile.save(subspaceCommonVersionsJson, subspaceCommonVersionsPath);
+    Console.success(
+      `Removed ${Colorize.bold(`${countRemoved}`)} unused alternative versions from subspace ${Colorize.bold(
+        subspaceName
+      )}!`
+    );
+  } else {
+    Console.success(`No unused alternative versions found for subspace ${Colorize.bold(subspaceName)}!`);
+  }
+};
+
+const removeSubsetDependencyVersions = async (
+  subspaceName: string,
+  subspaceDependencies: Map<string, Map<string, string[]>>
+): Promise<void> => {
+  const multipleVersionDependencies: string[] = Array.from(subspaceDependencies.keys()).filter(
+    (dependency) => subspaceDependencies.get(dependency)!.size > 1
+  );
+
+  if (multipleVersionDependencies.length === 0) {
+    Console.success(
+      `The subspace ${Colorize.bold(subspaceName)} doesn't contain alternative versions! Exiting...`
+    );
+    return;
+  }
+
+  if (await scanForAllDependenciesPrompt()) {
+    Console.log(`Removing subset versions for subspace ${Colorize.bold(subspaceName)}...`);
+    await Promise.all(
+      Array.from(subspaceDependencies.entries()).map(([dependency, versionsMap]) =>
+        removeSubsetDependency(subspaceName, dependency, versionsMap)
+      )
+    ).then((countPerDependency) => {
+      const count: number = countPerDependency.reduce((a, b) => a + b, 0);
+      if (count > 0) {
+        Console.success(`Removed ${Colorize.bold(`${count}`)} subset alternative versions!`);
+      } else {
+        Console.success(`No alternative versions have been removed!`);
+      }
+    });
+
+    return;
+  }
+
+  do {
+    const selectedDependency: string = await chooseDependencyPrompt(multipleVersionDependencies);
+
+    Console.log(`Removing subset versions for dependency ${Colorize.bold(selectedDependency)}...`);
+    const count: number = await removeSubsetDependency(
+      subspaceName,
+      selectedDependency,
+      subspaceDependencies.get(selectedDependency) as Map<string, string[]>
+    );
+
+    if (count > 0) {
+      Console.success(
+        `Removed ${Colorize.bold(`${count}`)} subset alternative versions for dependency ${Colorize.bold(
+          selectedDependency
+        )}!`
+      );
+    } else {
+      Console.success(
+        `No alternative versions have been removed for dependency ${Colorize.bold(selectedDependency)}!`
+      );
+    }
+
+    const index: number = multipleVersionDependencies.indexOf(selectedDependency);
+    multipleVersionDependencies.splice(index, 1);
+  } while (multipleVersionDependencies.length > 0 && (await confirmNextDependencyPrompt()));
+};
 
 export const cleanSubspace = async (): Promise<void> => {
   Console.debug('Executing clean subspace command...');
@@ -26,15 +256,24 @@ export const cleanSubspace = async (): Promise<void> => {
   }
 
   const targetSubspace: string = await chooseSubspacePrompt(targetSubspaces);
-  Console.title(`🛁 Cleaning subspace ${Colorize.underline(targetSubspace)} common versions...`);
+  Console.title(`🛁 Cleaning subspace ${Colorize.underline(targetSubspace)} alternative versions...`);
 
-  if (cleanSubspaceCommonVersions(targetSubspace)) {
-    Console.success(
-      `${Colorize.bold(
-        getRushSubspaceCommonVersionsFilePath(targetSubspace)
-      )} has been successfully refactored!`
-    );
-  } else {
-    Console.success(`The subspace ${Colorize.bold(targetSubspace)} doesn't require cleaning! Exiting...`);
+  let subspaceDependencies: Map<string, Map<string, string[]>> = getSubspaceDependencies(targetSubspace);
+  if (await scanForDuplicatedDependenciesPrompt()) {
+    removeDuplicatedDependencies(targetSubspace);
+    subspaceDependencies = getSubspaceDependencies(targetSubspace);
   }
+
+  if (await scanForSubsetDependencyVersionsPrompt()) {
+    await removeSubsetDependencyVersions(targetSubspace, subspaceDependencies);
+    subspaceDependencies = getSubspaceDependencies(targetSubspace);
+  }
+
+  if (await scanForUnusedDependencyVersionsPrompt()) {
+    removeUnusedAlternativeVersions(targetSubspace, subspaceDependencies);
+  }
+
+  Console.warn(
+    `Please run "rush update --subspace ${targetSubspace}" to update the subspace shrinkwrap file.`
+  );
 };

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cleanSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cleanSubspace.ts
@@ -6,7 +6,6 @@ import {
   scanForAllDependenciesPrompt
 } from './prompts/subspace';
 import Console from './providers/console';
-import { getRootPath } from './utilities/path';
 import { Colorize } from '@rushstack/terminal';
 import {
   getRushSubspaceCommonVersionsFilePath,
@@ -246,16 +245,14 @@ const removeSupersetDependencyVersions = async (
   } while (multipleVersionDependencies.length > 0 && (await confirmNextDependencyPrompt()));
 };
 
-export const cleanSubspace = async (targetMonorepoPath: string = getRootPath()): Promise<void> => {
+export const cleanSubspace = async (rootPath: string): Promise<void> => {
   Console.debug('Executing clean subspace command...');
 
-  const targetSubspaces: string[] = querySubspaces(targetMonorepoPath);
-  if (!isSubspaceSupported(targetMonorepoPath)) {
+  const targetSubspaces: string[] = querySubspaces(rootPath);
+  if (!isSubspaceSupported(rootPath)) {
     Console.error(
-      `The monorepo ${Colorize.bold(
-        targetMonorepoPath
-      )} doesn't support subspaces! Make sure you have ${Colorize.bold(
-        getRushSubspacesConfigurationJsonPath(targetMonorepoPath)
+      `The monorepo ${Colorize.bold(rootPath)} doesn't support subspaces! Make sure you have ${Colorize.bold(
+        getRushSubspacesConfigurationJsonPath(rootPath)
       )} with the ${Colorize.bold(RushConstants.defaultSubspaceName)} subspace. Exiting...`
     );
     return;
@@ -266,20 +263,20 @@ export const cleanSubspace = async (targetMonorepoPath: string = getRootPath()):
 
   let subspaceDependencies: Map<string, Map<string, string[]>> = getSubspaceDependencies(
     targetSubspace,
-    targetMonorepoPath
+    rootPath
   );
   if (await scanForDuplicatedDependenciesPrompt()) {
-    removeDuplicatedDependencies(targetSubspace, targetMonorepoPath);
-    subspaceDependencies = getSubspaceDependencies(targetSubspace, targetMonorepoPath);
+    removeDuplicatedDependencies(targetSubspace, rootPath);
+    subspaceDependencies = getSubspaceDependencies(targetSubspace, rootPath);
   }
 
   if (await scanForSupersetDependencyVersionsPrompt()) {
-    await removeSupersetDependencyVersions(targetSubspace, subspaceDependencies, targetMonorepoPath);
-    subspaceDependencies = getSubspaceDependencies(targetSubspace, targetMonorepoPath);
+    await removeSupersetDependencyVersions(targetSubspace, subspaceDependencies, rootPath);
+    subspaceDependencies = getSubspaceDependencies(targetSubspace, rootPath);
   }
 
   if (await scanForUnusedDependencyVersionsPrompt()) {
-    removeUnusedAlternativeVersions(targetSubspace, subspaceDependencies, targetMonorepoPath);
+    removeUnusedAlternativeVersions(targetSubspace, subspaceDependencies, rootPath);
   }
 
   Console.warn(

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cleanSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cleanSubspace.ts
@@ -44,26 +44,26 @@ const removeSupersetDependency = async (
   const newValidVersions: string[] = rSortVersions(versions).reduce<string[]>((prevVersions, currVersion) => {
     const newVersions: string[] = [...prevVersions];
     if (newVersions.includes(currVersion)) {
-      // do nothing.
-    } else if (RESERVED_VERSIONS.includes(currVersion)) {
+      return newVersions;
+    }
+
+    const newSubsetVersion: string | undefined = newVersions.find((newVersion) =>
+      subsetVersion(newVersion, currVersion)
+    );
+
+    if (RESERVED_VERSIONS.includes(currVersion) || !newSubsetVersion) {
       newVersions.push(currVersion);
     } else {
-      // Find and replace versions with subset versions
-      const newSubsetVersion: string | undefined = newVersions.find((newVersion) =>
-        subsetVersion(newVersion, currVersion)
-      );
-      if (newSubsetVersion) {
-        // Update projects with new subset version
-        versionsMap.get(currVersion)?.forEach((projectName) => {
-          if (updateProjectDependency(projectName, dependencyName, newSubsetVersion, rootPath)) {
-            Console.debug(
-              `Updated project ${Colorize.bold(projectName)} for dependency ${Colorize.bold(
-                dependencyName
-              )} ${Colorize.bold(currVersion)} => ${Colorize.bold(newSubsetVersion)}!`
-            );
-          }
-        });
-      }
+      // Update projects with new subset version
+      versionsMap.get(currVersion)?.forEach((projectName) => {
+        if (updateProjectDependency(projectName, dependencyName, newSubsetVersion, rootPath)) {
+          Console.debug(
+            `Updated project ${Colorize.bold(projectName)} for dependency ${Colorize.bold(
+              dependencyName
+            )} ${Colorize.bold(currVersion)} => ${Colorize.bold(newSubsetVersion)}!`
+          );
+        }
+      });
     }
 
     return newVersions;

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
@@ -8,6 +8,7 @@ import { migrateProject } from './migrateProject';
 import Console from './providers/console';
 import { interactMenu } from './interactMenu';
 import { cleanSubspace } from './cleanSubspace';
+import { getRootPath } from './utilities/path';
 
 inquirer.registerPrompt('search-list', inquirerSearchList);
 
@@ -26,14 +27,17 @@ program
     Console.title(`🚀 Rush Migrate Subspace Plugin - version ${packageJson.version}`);
     Console.newLine();
 
+    const sourceMonorepoPath: string = getRootPath();
+    const targetMonorepoPath: string = getRootPath();
+
     if (sync) {
-      await syncVersions();
+      await syncVersions(targetMonorepoPath);
     } else if (move) {
-      await migrateProject();
+      await migrateProject(sourceMonorepoPath, targetMonorepoPath);
     } else if (clean) {
-      await cleanSubspace();
+      await cleanSubspace(targetMonorepoPath);
     } else {
-      await interactMenu();
+      await interactMenu(sourceMonorepoPath, targetMonorepoPath);
     }
   });
 

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
@@ -23,7 +23,7 @@ program
     const packageJson: IPackageJson = JsonFile.load(`${path.resolve(__dirname, '../package.json')}`);
 
     Console.enableDebug(debug);
-    Console.title(`🚀 Welcome to the Rush Migrate Subspace Plugin! Version: ${packageJson.version}`);
+    Console.title(`🚀 Rush Migrate Subspace Plugin - version ${packageJson.version}`);
     Console.newLine();
 
     if (sync) {

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander';
 import inquirer from 'inquirer';
+import path from 'path';
+import { IPackageJson, JsonFile } from '@rushstack/node-core-library';
 import inquirerSearchList from 'inquirer-search-list';
 import { syncVersions } from './syncVersions';
 import { migrateProject } from './migrateProject';
@@ -18,8 +20,10 @@ program
   .option('--debug', 'to provide debug logs')
   .description('Example: rush migrate-subspace [--move] [--sync] [--debug] [--clean]')
   .action(async ({ sync, debug, move, clean }) => {
+    const packageJson: IPackageJson = JsonFile.load(`${path.resolve(__dirname, '../package.json')}`);
+
     Console.enableDebug(debug);
-    Console.title('🚀 Welcome to the Rush Migrate Subspace Plugin!');
+    Console.title(`🚀 Welcome to the Rush Migrate Subspace Plugin! Version: ${packageJson.version}`);
     Console.newLine();
 
     if (sync) {

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
@@ -5,6 +5,7 @@ import { syncVersions } from './syncVersions';
 import { migrateProject } from './migrateProject';
 import Console from './providers/console';
 import { interactMenu } from './interactMenu';
+import { cleanSubspace } from './cleanSubspace';
 
 inquirer.registerPrompt('search-list', inquirerSearchList);
 
@@ -13,9 +14,10 @@ const program: Command = new Command();
 program
   .option('--sync', 'to sync the versions in a subspace')
   .option('--move', 'to move projects to a new subspace')
+  .option('--clean', 'to reduce subspace alternative versions')
   .option('--debug', 'to provide debug logs')
-  .description('Example: rush migrate-subspace [--move] [--sync] [--debug]')
-  .action(async ({ sync, debug, move }) => {
+  .description('Example: rush migrate-subspace [--move] [--sync] [--debug] [--clean]')
+  .action(async ({ sync, debug, move, clean }) => {
     Console.enableDebug(debug);
     Console.title('🚀 Welcome to the Rush Migrate Subspace Plugin!');
     Console.newLine();
@@ -24,6 +26,8 @@ program
       await syncVersions();
     } else if (move) {
       await migrateProject();
+    } else if (clean) {
+      await cleanSubspace();
     } else {
       await interactMenu();
     }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/constants/versions.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/constants/versions.ts
@@ -1,0 +1,4 @@
+export const LATEST_VERSION: string = 'latest';
+export const LOCAL_VERSION: string = 'workspace:*';
+
+export const RESERVED_VERSIONS: string[] = [LATEST_VERSION, LOCAL_VERSION];

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/createSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/createSubspace.ts
@@ -8,9 +8,9 @@ import {
 import { ISubspacesConfigurationJson } from '@rushstack/rush-sdk/lib/api/SubspacesConfiguration';
 import { getRushSubspaceConfigurationFolderPath } from '../utilities/subspace';
 
-export const createSubspace = async (subspaceName: string): Promise<void> => {
+export const createSubspace = async (subspaceName: string, rootPath: string): Promise<void> => {
   Console.debug(`Creating subspace ${Colorize.bold(subspaceName)}...`);
-  const subspaceConfigFolder: string = getRushSubspaceConfigurationFolderPath(subspaceName);
+  const subspaceConfigFolder: string = getRushSubspaceConfigurationFolderPath(subspaceName, rootPath);
   FileSystem.ensureFolder(subspaceConfigFolder);
 
   const files: string[] = ['.npmrc', 'common-versions.json', 'repo-state.json'];
@@ -23,17 +23,19 @@ export const createSubspace = async (subspaceName: string): Promise<void> => {
     }
   }
 
-  const subspacesConfigJson: ISubspacesConfigurationJson = loadRushSubspacesConfiguration();
+  const subspacesConfigJson: ISubspacesConfigurationJson = loadRushSubspacesConfiguration(rootPath);
   if (!subspacesConfigJson.subspaceNames.includes(subspaceName)) {
     Console.debug(
-      `Updating ${getRushSubspacesConfigurationJsonPath()} by adding ${Colorize.bold(subspaceName)}...`
+      `Updating ${getRushSubspacesConfigurationJsonPath(rootPath)} by adding ${Colorize.bold(
+        subspaceName
+      )}...`
     );
     const newSubspacesConfigJson: ISubspacesConfigurationJson = {
       ...subspacesConfigJson,
       subspaceNames: [...subspacesConfigJson.subspaceNames, subspaceName]
     };
 
-    JsonFile.save(newSubspacesConfigJson, getRushSubspacesConfigurationJsonPath(), {
+    JsonFile.save(newSubspacesConfigJson, getRushSubspacesConfigurationJsonPath(rootPath), {
       updateExistingFile: true
     });
   }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/generateReport.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/generateReport.ts
@@ -5,16 +5,15 @@ import { Colorize } from '@rushstack/terminal';
 import { RushNameConstants } from '../constants/paths';
 import { getProjectMismatches } from '../utilities/project';
 import { VersionMismatchFinderEntity } from '@rushstack/rush-sdk/lib/logic/versionMismatch/VersionMismatchFinderEntity';
-import { getRootPath } from '../utilities/path';
 import { sortVersions } from '../utilities/dependency';
 
-export const generateReport = async (projectName: string): Promise<void> => {
+export const generateReport = async (projectName: string, rootPath: string): Promise<void> => {
   Console.debug(`Generating mismatches report for the project ${Colorize.bold(projectName)}...`);
 
   const projectMismatches: ReadonlyMap<
     string,
     ReadonlyMap<string, readonly VersionMismatchFinderEntity[]>
-  > = getProjectMismatches(projectName);
+  > = getProjectMismatches(projectName, rootPath);
   if (projectMismatches.size === 0) {
     Console.success(`No mismatches found for the project ${Colorize.bold(projectName)}.`);
     return;
@@ -39,7 +38,7 @@ export const generateReport = async (projectName: string): Promise<void> => {
     }
   }
 
-  const reportFilePath: string = `${getRootPath()}/${projectName}_${RushNameConstants.AnalysisFileName}`;
+  const reportFilePath: string = `${rootPath}/${projectName}_${RushNameConstants.AnalysisFileName}`;
   const jsonFilePath: string = await enterReportFileLocationPrompt(reportFilePath);
   JsonFile.save(output, jsonFilePath, { prettyFormatting: true });
   Console.success(`Saved report file to ${Colorize.bold(jsonFilePath)}.`);

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/initSubspaces.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/initSubspaces.ts
@@ -5,12 +5,11 @@ import { RushConstants } from '@rushstack/rush-sdk';
 import { getRushSubspacesConfigurationJsonPath } from '../utilities/repository';
 import { getRushSubspaceConfigurationFolderPath } from '../utilities/subspace';
 import { Colorize } from '@rushstack/terminal';
-import { getRootPath } from '../utilities/path';
 
-export const initSubspaces = async (): Promise<void> => {
-  Console.debug(`Starting subspaces feature on ${Colorize.bold(getRootPath())}...`);
+export const initSubspaces = async (rootPath: string): Promise<void> => {
+  Console.debug(`Starting subspaces feature on ${Colorize.bold(rootPath)}...`);
 
-  const subspacesConfigurationJsonPath: string = getRushSubspacesConfigurationJsonPath();
+  const subspacesConfigurationJsonPath: string = getRushSubspacesConfigurationJsonPath(rootPath);
   if (!FileSystem.exists(subspacesConfigurationJsonPath)) {
     FileSystem.copyFile({
       sourcePath: FileSystem.getRealPath(`${__dirname}/../templates/subspaces.json`),
@@ -20,7 +19,9 @@ export const initSubspaces = async (): Promise<void> => {
     Console.success(`${Colorize.bold(subspacesConfigurationJsonPath)} file created successfully!`);
   }
 
-  if (!FileSystem.exists(getRushSubspaceConfigurationFolderPath(RushConstants.defaultSubspaceName))) {
-    await createSubspace(RushConstants.defaultSubspaceName);
+  if (
+    !FileSystem.exists(getRushSubspaceConfigurationFolderPath(RushConstants.defaultSubspaceName, rootPath))
+  ) {
+    await createSubspace(RushConstants.defaultSubspaceName, rootPath);
   }
 };

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/syncProjectDependencies.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/syncProjectDependencies.ts
@@ -23,11 +23,14 @@ import { generateReport } from './generateReport';
 const addVersionToCommonVersionConfiguration = (
   subspaceName: string,
   dependencyName: string,
-  selectedVersion: string
+  selectedVersion: string,
+  rootPath: string
 ): void => {
-  const subspaceCommonVersionsPath: string = getRushSubspaceCommonVersionsFilePath(subspaceName);
-  const subspaceCommonVersionsJson: RushSubspaceCommonVersionsJson =
-    loadRushSubspaceCommonVersions(subspaceName);
+  const subspaceCommonVersionsPath: string = getRushSubspaceCommonVersionsFilePath(subspaceName, rootPath);
+  const subspaceCommonVersionsJson: RushSubspaceCommonVersionsJson = loadRushSubspaceCommonVersions(
+    subspaceName,
+    rootPath
+  );
 
   Console.debug(
     `Adding ${Colorize.bold(selectedVersion)} to allowedAlternativeVersions of ${Colorize.bold(
@@ -49,16 +52,19 @@ const addVersionToCommonVersionConfiguration = (
 
 const syncDependencyVersion = async (
   dependencyToUpdate: string,
-  projectToUpdate: string
+  projectToUpdate: string,
+  rootPath: string
 ): Promise<boolean> => {
   const dependencyName: string = dependencyToUpdate.replace(' (cyclic)', '');
-  const project: IRushConfigurationProjectJson | undefined = queryProject(projectToUpdate);
+  const project: IRushConfigurationProjectJson | undefined = queryProject(projectToUpdate, rootPath);
   if (!project || !project.subspaceName) {
     return false;
   }
 
-  const projectDependencies: IPackageJsonDependencyTable | undefined =
-    getProjectDependencies(projectToUpdate);
+  const projectDependencies: IPackageJsonDependencyTable | undefined = getProjectDependencies(
+    projectToUpdate,
+    rootPath
+  );
   const currentVersion: string | undefined = projectDependencies?.[dependencyName];
   if (!currentVersion) {
     Console.error(
@@ -69,12 +75,16 @@ const syncDependencyVersion = async (
     return false;
   }
 
-  const subspaceCommonVersionsJson: JsonObject = loadRushSubspaceCommonVersions(project.subspaceName);
+  const subspaceCommonVersionsJson: JsonObject = loadRushSubspaceCommonVersions(
+    project.subspaceName,
+    rootPath
+  );
   const subspaceAlternativeVersions: string[] =
     subspaceCommonVersionsJson.allowedAlternativeVersions[dependencyName] || [];
 
   const subspaceDependencies: Map<string, Map<string, string[]>> = getSubspaceDependencies(
-    project.subspaceName
+    project.subspaceName,
+    rootPath
   );
 
   const subspaceVersionsMap: Map<string, string[]> = subspaceDependencies.get(dependencyName) as Map<
@@ -118,22 +128,22 @@ const syncDependencyVersion = async (
     return false;
   } else if (versionToSync === 'manual') {
     const newVersion: string = (await enterVersionPrompt(dependencyName)).trim();
-    addVersionToCommonVersionConfiguration(project.subspaceName, dependencyName, newVersion);
-    await updateProjectDependency(projectToUpdate, dependencyName, newVersion);
+    addVersionToCommonVersionConfiguration(project.subspaceName, dependencyName, newVersion, rootPath);
+    await updateProjectDependency(projectToUpdate, dependencyName, newVersion, rootPath);
   } else if (versionToSync === 'alternative') {
-    addVersionToCommonVersionConfiguration(project.subspaceName, dependencyName, currentVersion);
+    addVersionToCommonVersionConfiguration(project.subspaceName, dependencyName, currentVersion, rootPath);
   } else {
-    await updateProjectDependency(projectToUpdate, dependencyName, versionToSync);
+    await updateProjectDependency(projectToUpdate, dependencyName, versionToSync, rootPath);
   }
 
   return true;
 };
 
-const fetchProjectMismatches = (projectName: string): string[] => {
+const fetchProjectMismatches = (projectName: string, rootPath: string): string[] => {
   const projectMismatches: ReadonlyMap<
     string,
     ReadonlyMap<string, readonly VersionMismatchFinderEntity[]>
-  > = getProjectMismatches(projectName);
+  > = getProjectMismatches(projectName, rootPath);
 
   const mismatchedDependencies: string[] = Array.from(projectMismatches.keys());
   if (mismatchedDependencies.length === 0) {
@@ -157,16 +167,19 @@ const fetchProjectMismatches = (projectName: string): string[] => {
   return mismatchedDependencies;
 };
 
-export const syncProjectMismatchedDependencies = async (projectName: string): Promise<boolean> => {
+export const syncProjectMismatchedDependencies = async (
+  projectName: string,
+  rootPath: string
+): Promise<boolean> => {
   Console.title(`🔄 Syncing version mismatches for project ${Colorize.bold(projectName)}...`);
 
-  let mismatchedDependencies: string[] = fetchProjectMismatches(projectName);
+  let mismatchedDependencies: string[] = fetchProjectMismatches(projectName, rootPath);
   if (mismatchedDependencies.length === 0) {
     Console.success(`No mismatches found in the project ${Colorize.bold(projectName)}!`);
     return true;
   }
 
-  const project: IRushConfigurationProjectJson | undefined = queryProject(projectName);
+  const project: IRushConfigurationProjectJson | undefined = queryProject(projectName, rootPath);
   if (!project || !project.subspaceName) {
     Console.error(`Project ${Colorize.bold(projectName)} is not part of a subspace!`);
     return true;
@@ -175,7 +188,7 @@ export const syncProjectMismatchedDependencies = async (projectName: string): Pr
   const nextCommand: string = await chooseSyncCommandPrompt(project.packageName);
   switch (nextCommand) {
     case 'report':
-      await generateReport(project.packageName);
+      await generateReport(project.packageName, rootPath);
       break;
     case 'fix':
       do {
@@ -183,8 +196,8 @@ export const syncProjectMismatchedDependencies = async (projectName: string): Pr
           mismatchedDependencies,
           ` (${Colorize.bold(`${mismatchedDependencies.length}`)} mismatched dependencies)`
         );
-        if (await syncDependencyVersion(selectedDependency, projectName)) {
-          mismatchedDependencies = fetchProjectMismatches(projectName);
+        if (await syncDependencyVersion(selectedDependency, projectName, rootPath)) {
+          mismatchedDependencies = fetchProjectMismatches(projectName, rootPath);
         }
       } while (
         mismatchedDependencies.length > 0 &&

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/syncProjectDependencies.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/syncProjectDependencies.ts
@@ -179,11 +179,17 @@ export const syncProjectMismatchedDependencies = async (projectName: string): Pr
       break;
     case 'fix':
       do {
-        const selectedDependency: string = await chooseDependencyPrompt(mismatchedDependencies);
+        const selectedDependency: string = await chooseDependencyPrompt(
+          mismatchedDependencies,
+          ` (${Colorize.bold(`${mismatchedDependencies.length}`)} mismatched dependencies)`
+        );
         if (await syncDependencyVersion(selectedDependency, projectName)) {
           mismatchedDependencies = fetchProjectMismatches(projectName);
         }
-      } while (mismatchedDependencies.length > 0 && (await confirmNextDependencyPrompt(projectName)));
+      } while (
+        mismatchedDependencies.length > 0 &&
+        (await confirmNextDependencyPrompt(` (Current project: ${Colorize.bold(projectName)})`))
+      );
 
       break;
     case 'skip':

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateEdenProject.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateEdenProject.ts
@@ -3,15 +3,15 @@ import { RushNameConstants } from '../constants/paths';
 import Console from '../providers/console';
 import { Colorize } from '@rushstack/terminal';
 import { IRushConfigurationProjectJson } from '@rushstack/rush-sdk/lib/api/RushConfigurationProject';
-import { getRootPath } from '../utilities/path';
 
 export async function updateEdenProject(
   sourceProject: IRushConfigurationProjectJson,
-  targetProjectFolderPath: string
+  targetProjectFolderPath: string,
+  rootPath: string
 ): Promise<void> {
-  Console.debug(`Update monorepo eden configuration on ${Colorize.bold(getRootPath())}...`);
+  Console.debug(`Update monorepo eden configuration on ${Colorize.bold(rootPath)}...`);
 
-  const edenPipelineFilePath: string = `${getRootPath()}/${RushNameConstants.EdenPipelineFileName}`;
+  const edenPipelineFilePath: string = `${rootPath}/${RushNameConstants.EdenPipelineFileName}`;
   const edenPipelineJson: JsonObject = JsonFile.load(edenPipelineFilePath);
   for (const entry of Object.values<JsonObject>(edenPipelineJson.scene.scm)) {
     if (entry.pipelinePath?.includes(sourceProject.projectFolder)) {
@@ -30,7 +30,7 @@ export async function updateEdenProject(
     }
   }
 
-  const edenMonorepoFilePath: string = `${getRootPath()}/${RushNameConstants.EdenMonorepoFileName}`;
+  const edenMonorepoFilePath: string = `${rootPath}/${RushNameConstants.EdenMonorepoFileName}`;
   const edenMonorepoJson: JsonObject = JsonFile.load(edenMonorepoFilePath);
   const edenProject: JsonObject = edenMonorepoJson.packages.find(
     ({ name }: JsonObject) => name === sourceProject.packageName

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateProjectDependency.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateProjectDependency.ts
@@ -7,15 +7,16 @@ import Console from '../providers/console';
 export const updateProjectDependency = async (
   projectName: string,
   dependencyName: string,
-  newVersion: string
+  newVersion: string,
+  rootPath: string
 ): Promise<boolean> => {
-  const project: IRushConfigurationProjectJson | undefined = queryProject(projectName);
+  const project: IRushConfigurationProjectJson | undefined = queryProject(projectName, rootPath);
   if (!project) {
     Console.error(`Could not load find the project ${Colorize.bold(projectName)}.`);
     return false;
   }
 
-  const pkgJsonPath: string = getProjectPackageFilePath(project.projectFolder);
+  const pkgJsonPath: string = getProjectPackageFilePath(project.projectFolder, rootPath);
   if (!FileSystem.exists(pkgJsonPath)) {
     Console.error(`Could not load ${Colorize.bold(pkgJsonPath)}.`);
     return false;

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateRushConfiguration.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateRushConfiguration.ts
@@ -1,5 +1,4 @@
 import { IRushConfigurationProjectJson } from '@rushstack/rush-sdk/lib/api/RushConfigurationProject';
-import { getRootPath } from '../utilities/path';
 import { IRushConfigurationJson } from '@rushstack/rush-sdk/lib/api/RushConfiguration';
 import { loadRushConfiguration } from '../utilities/repository';
 import Console from '../providers/console';
@@ -10,10 +9,10 @@ import path from 'path';
 
 export const removeProjectFromRushConfiguration = (
   project: IRushConfigurationProjectJson,
-  monoRepoRootPath: string = getRootPath()
+  rootPath: string
 ): void => {
-  const rushConfigFile: string = `${monoRepoRootPath}/${RushConstants.rushJsonFilename}`;
-  const rushConfig: IRushConfigurationJson = loadRushConfiguration(monoRepoRootPath);
+  const rushConfigFile: string = `${rootPath}/${RushConstants.rushJsonFilename}`;
+  const rushConfig: IRushConfigurationJson = loadRushConfiguration(rootPath);
   const projectIndex: number = rushConfig.projects.findIndex(
     ({ packageName }) => packageName === project.packageName
   );
@@ -47,17 +46,17 @@ export const addProjectToRushConfiguration = (
   sourceProject: IRushConfigurationProjectJson,
   targetSubspace: string,
   targetProjectFolderPath: string,
-  monoRepoRootPath: string = getRootPath()
+  rootPath: string
 ): void => {
-  const rushConfigFile: string = `${monoRepoRootPath}/${RushConstants.rushJsonFilename}`;
-  const rushConfig: IRushConfigurationJson = loadRushConfiguration(monoRepoRootPath);
+  const rushConfigFile: string = `${rootPath}/${RushConstants.rushJsonFilename}`;
+  const rushConfig: IRushConfigurationJson = loadRushConfiguration(rootPath);
   const projectIndex: number = rushConfig.projects.findIndex(
     ({ packageName }) => packageName === sourceProject.packageName
   );
   let newTargetProject: IRushConfigurationProjectJson = {
     subspaceName: targetSubspace,
     packageName: sourceProject.packageName,
-    projectFolder: path.relative(monoRepoRootPath, targetProjectFolderPath),
+    projectFolder: path.relative(rootPath, targetProjectFolderPath),
     decoupledLocalDependencies: []
   };
 

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateSubspace.ts
@@ -12,10 +12,14 @@ import {
 
 const mergeSubspaceCommonVersionsFiles = (
   targetSubspaceName: string,
-  sourceSubspaceFolderPath: string
+  sourceSubspaceFolderPath: string,
+  rootPath: string
 ): void => {
   const sourceCommonVersionsFilePath: string = `${sourceSubspaceFolderPath}/${RushConstants.commonVersionsFilename}`;
-  const targetCommonVersionsFilePath: string = getRushSubspaceCommonVersionsFilePath(targetSubspaceName);
+  const targetCommonVersionsFilePath: string = getRushSubspaceCommonVersionsFilePath(
+    targetSubspaceName,
+    rootPath
+  );
 
   const sourceCommonVersions: RushSubspaceCommonVersionsJson = JsonFile.load(sourceCommonVersionsFilePath);
   if (FileSystem.exists(targetCommonVersionsFilePath)) {
@@ -97,15 +101,20 @@ const copySubspaceRepoStateFile = (
 };
 */
 
-const mergeSubspacePnpmFiles = (targetSubspaceName: string, sourceSubspaceFolderPath: string): void => {
+const mergeSubspacePnpmFiles = (
+  targetSubspaceName: string,
+  sourceSubspaceFolderPath: string,
+  rootPath: string
+): void => {
   const sourcePnpmFilePath: string = `${sourceSubspaceFolderPath}/${RushNameConstants.PnpmSubspaceFileName}`;
-  const targetPnpmFilePath: string = getRushSubspacePnpmFilePath(targetSubspaceName);
+  const targetPnpmFilePath: string = getRushSubspacePnpmFilePath(targetSubspaceName, rootPath);
 
   if (FileSystem.exists(sourcePnpmFilePath)) {
     if (FileSystem.exists(targetPnpmFilePath)) {
       const tempPnpmSubspaceFileName: string = `.pnpmfile-subspace-temp_${new Date().getTime()}.cjs`;
       const targetPnpmTempFilePath: string = `${getRushSubspaceConfigurationFolderPath(
-        targetSubspaceName
+        targetSubspaceName,
+        rootPath
       )}/${tempPnpmSubspaceFileName}`;
       Console.debug(
         `Duplicating temporary ${Colorize.bold(sourcePnpmFilePath)} into ${Colorize.bold(
@@ -139,9 +148,13 @@ const mergeSubspacePnpmFiles = (targetSubspaceName: string, sourceSubspaceFolder
   }
 };
 
-const copySubspaceNpmRcFile = (targetSubspaceName: string, sourceSubspaceFolderPath: string): void => {
+const copySubspaceNpmRcFile = (
+  targetSubspaceName: string,
+  sourceSubspaceFolderPath: string,
+  rootPath: string
+): void => {
   const sourceNpmRcFilePath: string = `${sourceSubspaceFolderPath}/${RushNameConstants.NpmRcFileName}`;
-  const targetNpmRcFilePath: string = getRushSubspaceNpmRcFilePath(targetSubspaceName);
+  const targetNpmRcFilePath: string = getRushSubspaceNpmRcFilePath(targetSubspaceName, rootPath);
 
   if (FileSystem.exists(sourceNpmRcFilePath)) {
     Console.debug(
@@ -156,10 +169,11 @@ const copySubspaceNpmRcFile = (targetSubspaceName: string, sourceSubspaceFolderP
 
 export const updateSubspace = async (
   targetSubspaceName: string,
-  sourceSubspaceConfigurationFolderPath: string
+  sourceSubspaceConfigurationFolderPath: string,
+  rootPath: string
 ): Promise<void> => {
-  copySubspaceNpmRcFile(targetSubspaceName, sourceSubspaceConfigurationFolderPath);
-  mergeSubspaceCommonVersionsFiles(targetSubspaceName, sourceSubspaceConfigurationFolderPath);
+  copySubspaceNpmRcFile(targetSubspaceName, sourceSubspaceConfigurationFolderPath, rootPath);
+  mergeSubspaceCommonVersionsFiles(targetSubspaceName, sourceSubspaceConfigurationFolderPath, rootPath);
   // copySubspaceRepoStateFile(sourceSubspaceConfigurationFolderPath, targetSubspaceConfigurationFolderPath);
-  mergeSubspacePnpmFiles(targetSubspaceName, sourceSubspaceConfigurationFolderPath);
+  mergeSubspacePnpmFiles(targetSubspaceName, sourceSubspaceConfigurationFolderPath, rootPath);
 };

--- a/rush-plugins/rush-migrate-subspace-plugin/src/interactMenu.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/interactMenu.ts
@@ -4,7 +4,7 @@ import { chooseCommandPrompt } from './prompts/command';
 import Console from './providers/console';
 import { syncVersions } from './syncVersions';
 
-export const interactMenu = async (): Promise<void> => {
+export const interactMenu = async (sourceMonorepoPath: string, targetMonorepoPath: string): Promise<void> => {
   let exitApplication: boolean = false;
   do {
     const nextCommand: string = await chooseCommandPrompt();
@@ -14,17 +14,17 @@ export const interactMenu = async (): Promise<void> => {
         break;
 
       case 'move':
-        await migrateProject();
+        await migrateProject(sourceMonorepoPath, targetMonorepoPath);
         Console.newLine();
         break;
 
       case 'sync':
-        await syncVersions();
+        await syncVersions(targetMonorepoPath);
         Console.newLine();
         break;
 
       case 'clean':
-        await cleanSubspace();
+        await cleanSubspace(targetMonorepoPath);
         Console.newLine();
         break;
     }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/interactMenu.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/interactMenu.ts
@@ -1,3 +1,4 @@
+import { cleanSubspace } from './cleanSubspace';
 import { migrateProject } from './migrateProject';
 import { chooseCommandPrompt } from './prompts/command';
 import Console from './providers/console';
@@ -19,6 +20,11 @@ export const interactMenu = async (): Promise<void> => {
 
       case 'sync':
         await syncVersions();
+        Console.newLine();
+        break;
+
+      case 'clean':
+        await cleanSubspace();
         Console.newLine();
         break;
     }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
@@ -2,7 +2,6 @@ import { chooseSubspacePrompt } from './prompts/subspace';
 import { addProjectToSubspace } from './functions/addProjectToSubspace';
 import { chooseProjectPrompt, confirmNextProjectToAddPrompt } from './prompts/project';
 import Console from './providers/console';
-import { getRootPath } from './utilities/path';
 import { Colorize } from '@rushstack/terminal';
 import { updateSubspace } from './functions/updateSubspace';
 import { getRushSubspaceConfigurationFolderPath, isSubspaceSupported } from './utilities/subspace';
@@ -16,7 +15,10 @@ import {
 import { RushConstants } from '@rushstack/rush-sdk';
 import { syncProjectMismatchedDependencies } from './functions/syncProjectDependencies';
 
-export const migrateProject = async (targetMonorepoPath: string = getRootPath()): Promise<void> => {
+export const migrateProject = async (
+  sourceMonorepoPath: string,
+  targetMonorepoPath: string
+): Promise<void> => {
   Console.debug('Executing project migration command...');
 
   Console.title(`🔍 Analyzing if monorepo ${Colorize.underline(targetMonorepoPath)} supports subspaces...`);
@@ -54,8 +56,6 @@ export const migrateProject = async (targetMonorepoPath: string = getRootPath())
    *   `The script will migrate from ${Colorize.bold(sourceMonorepoPath)} to ${Colorize.bold(getRootPath())}`
    * );
    */
-
-  const sourceMonorepoPath: string = getRootPath();
 
   /**
    * WARN: Disabling creating new subspaces for now.

--- a/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
@@ -16,36 +16,36 @@ import {
 import { RushConstants } from '@rushstack/rush-sdk';
 import { syncProjectMismatchedDependencies } from './functions/syncProjectDependencies';
 
-export const migrateProject = async (): Promise<void> => {
+export const migrateProject = async (targetMonorepoPath: string = getRootPath()): Promise<void> => {
   Console.debug('Executing project migration command...');
 
-  Console.title(`🔍 Analyzing if monorepo ${Colorize.underline(getRootPath())} supports subspaces...`);
+  Console.title(`🔍 Analyzing if monorepo ${Colorize.underline(targetMonorepoPath)} supports subspaces...`);
 
   /**
    * WARN: Disabling auto subspace initialization for now.
    * if (!isSubspaceSupported()) {
    *     Console.warn(
-   *  `The monorepo ${Colorize.bold(getRootPath())} doesn't contain subspaces. Initializing subspaces...`
+   *  `The monorepo ${Colorize.bold(rootPath)} doesn't contain subspaces. Initializing subspaces...`
    *);
    * await initSubspaces();
    * }
    */
 
-  const targetSubspaces: string[] = querySubspaces();
-  if (!isSubspaceSupported() || targetSubspaces.length === 0) {
+  const targetSubspaces: string[] = querySubspaces(targetMonorepoPath);
+  if (!isSubspaceSupported(targetMonorepoPath) || targetSubspaces.length === 0) {
     Console.error(
       `The monorepo ${Colorize.bold(
-        getRootPath()
+        targetMonorepoPath
       )} doesn't support subspaces! Make sure you have ${Colorize.bold(
-        getRushSubspacesConfigurationJsonPath()
+        getRushSubspacesConfigurationJsonPath(targetMonorepoPath)
       )} with the ${Colorize.bold(RushConstants.defaultSubspaceName)} subspace. Exiting...`
     );
     return;
   }
 
-  Console.success(`Monorepo ${Colorize.bold(getRootPath())} fully supports subspaces!`);
+  Console.success(`Monorepo ${Colorize.bold(targetMonorepoPath)} fully supports subspaces!`);
 
-  Console.title(`🔍 Finding projects to migrate to ${Colorize.bold(getRootPath())}...`);
+  Console.title(`🔍 Finding projects to migrate to ${Colorize.bold(targetMonorepoPath)}...`);
 
   /**
    * WARN: Disabling different repository selection for now.
@@ -76,7 +76,10 @@ export const migrateProject = async (): Promise<void> => {
   // Loop until user asks to quit
   do {
     const sourceProjects: IRushConfigurationProjectJson[] = queryProjects(sourceMonorepoPath);
-    const sourceAvailableProjects: IRushConfigurationProjectJson[] = isExternalMonorepo(sourceMonorepoPath)
+    const sourceAvailableProjects: IRushConfigurationProjectJson[] = isExternalMonorepo(
+      sourceMonorepoPath,
+      targetMonorepoPath
+    )
       ? sourceProjects
       : sourceProjects.filter(({ subspaceName }) => subspaceName !== targetSubspace);
 
@@ -108,11 +111,16 @@ export const migrateProject = async (): Promise<void> => {
         sourceProjectToMigrate.projectFolder
       );
 
-      await updateSubspace(targetSubspace, sourceSubspaceConfigurationFolderPath);
+      await updateSubspace(targetSubspace, sourceSubspaceConfigurationFolderPath, targetMonorepoPath);
     }
 
-    await addProjectToSubspace(sourceProjectToMigrate, targetSubspace, sourceMonorepoPath);
-    await syncProjectMismatchedDependencies(sourceProjectToMigrate.packageName);
+    await addProjectToSubspace(
+      sourceProjectToMigrate,
+      targetSubspace,
+      sourceMonorepoPath,
+      targetMonorepoPath
+    );
+    await syncProjectMismatchedDependencies(sourceProjectToMigrate.packageName, targetMonorepoPath);
   } while (await confirmNextProjectToAddPrompt(targetSubspace));
 
   Console.warn(

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/command.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/command.ts
@@ -9,6 +9,7 @@ export const chooseCommandPrompt = async (): Promise<string> => {
       choices: [
         { name: 'Move a project to a new subspace', value: 'move' },
         { name: 'Scan & fix version mismatches', value: 'sync' },
+        { name: 'Clean common subspace versions', value: 'clean' },
         { name: 'Exit application', value: 'exit' }
       ]
     }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/dependency.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/dependency.ts
@@ -2,11 +2,11 @@ import { Colorize } from '@rushstack/terminal';
 import inquirer from 'inquirer';
 import { sortVersions } from '../utilities/dependency';
 
-export const confirmNextDependencyPrompt = async (projectName: string): Promise<boolean> => {
+export const confirmNextDependencyPrompt = async (suffix?: string): Promise<boolean> => {
   const { confirmNext } = await inquirer.prompt([
     {
-      message: `Do you want to fix another dependency?`,
-      suffix: ` (Current project: ${Colorize.bold(projectName)})`,
+      message: `Do you want to choose another dependency?`,
+      suffix,
       type: 'confirm',
       name: 'confirmNext',
       default: true
@@ -79,13 +79,13 @@ export const enterVersionPrompt = async (dependencyName: string): Promise<string
   return newVersion;
 };
 
-export const chooseDependencyPrompt = async (dependencies: string[]): Promise<string> => {
+export const chooseDependencyPrompt = async (dependencies: string[], suffix?: string): Promise<string> => {
   const { dependencyInput } = await inquirer.prompt([
     {
       type: 'list',
       name: 'dependencyInput',
-      message: `Please enter the dependency you wish to fix the mismatch.`,
-      suffix: ` (${Colorize.bold(`${dependencies.length}`)} mismatched dependencies)`,
+      message: `Please select the dependency name (Type to filter).`,
+      suffix,
 
       choices: dependencies.sort().map((name) => ({ name, value: name }))
     }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
@@ -84,7 +84,7 @@ export const scanForDuplicatedDependenciesPrompt = async (): Promise<boolean> =>
 export const scanForSupersetDependencyVersionsPrompt = async (): Promise<boolean> => {
   const { scanForSuperset } = await inquirer.prompt([
     {
-      message: 'Do you want to remove superset dependency versions in the subspace (EXPERIMENTAL)?',
+      message: '(EXPERIMENTAL) Do you want to remove superset dependency versions from the subspace?',
       name: 'scanForSuperset',
       type: 'confirm'
     }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
@@ -56,3 +56,50 @@ export const chooseCreateOrSelectSubspacePrompt = async (subspaces: string[]): P
 
   return subspaceSelection;
 };
+
+export const scanForUnusedDependencyVersionsPrompt = async (): Promise<boolean> => {
+  const { removeUnused } = await inquirer.prompt([
+    {
+      message: 'Do you want to remove unused alternative versions from the subspace?',
+      name: 'removeUnused',
+      type: 'confirm'
+    }
+  ]);
+
+  return removeUnused;
+};
+
+export const scanForDuplicatedDependenciesPrompt = async (): Promise<boolean> => {
+  const { scanForDuplicated } = await inquirer.prompt([
+    {
+      message: 'Do you want to scan for duplicated dependencies in the subspace?',
+      name: 'scanForDuplicated',
+      type: 'confirm'
+    }
+  ]);
+
+  return scanForDuplicated;
+};
+
+export const scanForSubsetDependencyVersionsPrompt = async (): Promise<boolean> => {
+  const { scanForSubset } = await inquirer.prompt([
+    {
+      message: 'Do you want to scan for subset dependency versions in the subspace?',
+      name: 'scanForSubset',
+      type: 'confirm'
+    }
+  ]);
+  return scanForSubset;
+};
+
+export const scanForAllDependenciesPrompt = async (): Promise<boolean> => {
+  const { executeForAll } = await inquirer.prompt([
+    {
+      message: `Do you want to scan for all dependencies?`,
+      type: 'confirm',
+      name: 'executeForAll'
+    }
+  ]);
+
+  return executeForAll;
+};

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
@@ -72,7 +72,7 @@ export const scanForUnusedDependencyVersionsPrompt = async (): Promise<boolean> 
 export const scanForDuplicatedDependenciesPrompt = async (): Promise<boolean> => {
   const { scanForDuplicated } = await inquirer.prompt([
     {
-      message: 'Do you want to scan for duplicated dependencies in the subspace?',
+      message: 'Do you want to remove duplicated dependencies in the subspace?',
       name: 'scanForDuplicated',
       type: 'confirm'
     }
@@ -84,7 +84,7 @@ export const scanForDuplicatedDependenciesPrompt = async (): Promise<boolean> =>
 export const scanForSupersetDependencyVersionsPrompt = async (): Promise<boolean> => {
   const { scanForSuperset } = await inquirer.prompt([
     {
-      message: 'Do you want to scan for superset dependency versions in the subspace?',
+      message: 'Do you want to remove superset dependency versions in the subspace (EXPERIMENTAL)?',
       name: 'scanForSuperset',
       type: 'confirm'
     }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
@@ -81,15 +81,15 @@ export const scanForDuplicatedDependenciesPrompt = async (): Promise<boolean> =>
   return scanForDuplicated;
 };
 
-export const scanForSubsetDependencyVersionsPrompt = async (): Promise<boolean> => {
-  const { scanForSubset } = await inquirer.prompt([
+export const scanForSupersetDependencyVersionsPrompt = async (): Promise<boolean> => {
+  const { scanForSuperset } = await inquirer.prompt([
     {
-      message: 'Do you want to scan for subset dependency versions in the subspace?',
-      name: 'scanForSubset',
+      message: 'Do you want to scan for superset dependency versions in the subspace?',
+      name: 'scanForSuperset',
       type: 'confirm'
     }
   ]);
-  return scanForSubset;
+  return scanForSuperset;
 };
 
 export const scanForAllDependenciesPrompt = async (): Promise<boolean> => {

--- a/rush-plugins/rush-migrate-subspace-plugin/src/syncVersions.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/syncVersions.ts
@@ -8,12 +8,12 @@ import { getSubspaceMismatches } from './utilities/subspace';
 import { chooseProjectPrompt, confirmNextProjectToSyncPrompt } from './prompts/project';
 import { syncProjectMismatchedDependencies } from './functions/syncProjectDependencies';
 
-const fetchSubspaceMismatchedProjects = (subspaceName: string): string[] => {
+const fetchSubspaceMismatchedProjects = (subspaceName: string, rootPath: string): string[] => {
   const mismatchedProjects: string[] = [];
   const subspaceMismatches: ReadonlyMap<
     string,
     ReadonlyMap<string, readonly VersionMismatchFinderEntity[]>
-  > = getSubspaceMismatches(subspaceName);
+  > = getSubspaceMismatches(subspaceName, rootPath);
 
   for (const [, versions] of subspaceMismatches) {
     for (const [, entities] of versions) {
@@ -32,19 +32,22 @@ const fetchSubspaceMismatchedProjects = (subspaceName: string): string[] => {
   return mismatchedProjects;
 };
 
-export const syncVersions = async (): Promise<void> => {
+export const syncVersions = async (targetMonorepoPath: string = getRootPath()): Promise<void> => {
   Console.debug('Synching project version...');
 
-  const sourceSubspaces: string[] = querySubspaces();
+  const sourceSubspaces: string[] = querySubspaces(targetMonorepoPath);
   if (sourceSubspaces.length === 0) {
-    Console.error(`No subspaces found in the monorepo ${Colorize.bold(getRootPath())}! Exiting...`);
+    Console.error(`No subspaces found in the monorepo ${Colorize.bold(targetMonorepoPath)}! Exiting...`);
     return;
   }
 
   const selectedSubspaceName: string = await chooseSubspacePrompt(sourceSubspaces);
   Console.title(`🔄 Syncing version mismatches for subspace ${Colorize.bold(selectedSubspaceName)}...`);
 
-  let mismatchedProjects: string[] = fetchSubspaceMismatchedProjects(selectedSubspaceName);
+  let mismatchedProjects: string[] = fetchSubspaceMismatchedProjects(
+    selectedSubspaceName,
+    targetMonorepoPath
+  );
   if (mismatchedProjects.length === 0) {
     Console.success(`No mismatches found in the subspace ${Colorize.bold(selectedSubspaceName)}! Exiting...`);
     return;
@@ -52,11 +55,11 @@ export const syncVersions = async (): Promise<void> => {
 
   do {
     const selectedProjectName: string = await chooseProjectPrompt(mismatchedProjects);
-    if (!(await syncProjectMismatchedDependencies(selectedProjectName))) {
+    if (!(await syncProjectMismatchedDependencies(selectedProjectName, targetMonorepoPath))) {
       return;
     }
 
-    mismatchedProjects = fetchSubspaceMismatchedProjects(selectedSubspaceName);
+    mismatchedProjects = fetchSubspaceMismatchedProjects(selectedSubspaceName, targetMonorepoPath);
   } while (mismatchedProjects.length > 0 && (await confirmNextProjectToSyncPrompt(selectedSubspaceName)));
 
   if (mismatchedProjects.length === 0) {

--- a/rush-plugins/rush-migrate-subspace-plugin/src/utilities/dependency.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/utilities/dependency.ts
@@ -1,9 +1,8 @@
 import { compare, eq, intersects, minVersion, satisfies, subset, valid, validRange } from 'semver';
+import { RESERVED_VERSIONS } from '../constants/versions';
 
 export const subsetVersion = (version1: string, version2: string): boolean => {
-  if (version1 === version2) {
-    return true;
-  } else if (['latest', 'workspace:*'].includes(version2)) {
+  if (RESERVED_VERSIONS.includes(version2)) {
     return true;
   } else if ((!valid(version1) && !validRange(version1)) || (!valid(version2) && !validRange(version2))) {
     return false;
@@ -26,10 +25,10 @@ export const sortVersions = (versions: string[]): string[] => {
     if (v1 === v2) {
       // e.g. 1.0.0 , 1.0.0
       return 0;
-    } else if (['latest', 'workspace:*'].includes(v1)) {
+    } else if (RESERVED_VERSIONS.includes(v1)) {
       // e.g. workspace:*, 1.0.0
       return 1;
-    } else if (['latest', 'workspace:*'].includes(v2)) {
+    } else if (RESERVED_VERSIONS.includes(v2)) {
       // e.g. 1.0.0, workspace:*
       return -1;
     } else if (!valid(v1) && !validRange(v1)) {

--- a/rush-plugins/rush-migrate-subspace-plugin/src/utilities/dependency.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/utilities/dependency.ts
@@ -71,13 +71,13 @@ export const sortVersions = (versions: string[]): string[] => {
   return newVersions;
 };
 
-export const rSortVersions = (versions: string[]): string[] => {
+export const reverseSortVersions = (versions: string[]): string[] => {
   return sortVersions(versions).reverse();
 };
 
 export const getClosestVersion = (targetVersion: string, versions: string[]): string | undefined => {
-  const rSortedVersions: string[] = rSortVersions(versions);
-  return rSortedVersions.find((version) => intersectsVersion(targetVersion, version));
+  const reverseSortedVersions: string[] = reverseSortVersions(versions);
+  return reverseSortedVersions.find((version) => intersectsVersion(targetVersion, version));
 };
 
 export const getRecommendedVersion = (targetVersion: string, versions: string[]): string | undefined => {

--- a/rush-plugins/rush-migrate-subspace-plugin/src/utilities/project.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/utilities/project.ts
@@ -98,3 +98,29 @@ export const getProjectMismatchedDependencies = (projectName: string): string[] 
 
   return Array.from(projectMismatches.keys());
 };
+
+export const updateProjectDependency = (
+  projectName: string,
+  dependencyName: string,
+  newVersion: string,
+  rootPath: string = getRootPath()
+): boolean => {
+  const project: IRushConfigurationProjectJson | undefined = queryProject(projectName, rootPath);
+  if (!project) {
+    return false;
+  }
+
+  const projectPackageFilePath: string = getProjectPackageFilePath(project.projectFolder, rootPath);
+  const projectPackageJson: IPackageJson = loadProjectPackageJson(project.projectFolder, rootPath);
+
+  if (projectPackageJson.dependencies![dependencyName]) {
+    projectPackageJson.dependencies![dependencyName] = newVersion;
+  }
+
+  if (projectPackageJson.devDependencies![dependencyName]) {
+    projectPackageJson.devDependencies![dependencyName] = newVersion;
+  }
+
+  JsonFile.save(projectPackageJson, projectPackageFilePath);
+  return true;
+};

--- a/rush-plugins/rush-migrate-subspace-plugin/src/utilities/repository.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/utilities/repository.ts
@@ -1,33 +1,27 @@
 import { JsonFile } from '@rushstack/node-core-library';
-import { getRootPath } from './path';
 import { IRushConfigurationJson } from '@rushstack/rush-sdk/lib/api/RushConfiguration';
 import { RushPathConstants } from '../constants/paths';
 import { ISubspacesConfigurationJson } from '@rushstack/rush-sdk/lib/api/SubspacesConfiguration';
 import { RushConstants } from '@rushstack/rush-sdk';
 
-export const getRushConfigurationJsonPath = (rootPath: string = getRootPath()): string =>
+export const getRushConfigurationJsonPath = (rootPath: string): string =>
   `${rootPath}/${RushConstants.rushJsonFilename}`;
 
-export const getRushSubspacesConfigurationJsonPath = (rootPath: string = getRootPath()): string =>
+export const getRushSubspacesConfigurationJsonPath = (rootPath: string): string =>
   `${rootPath}/${RushPathConstants.SubspacesConfigurationFilePath}`;
 
-export const loadRushConfiguration = (rootPath: string = getRootPath()): IRushConfigurationJson => {
+export const loadRushConfiguration = (rootPath: string): IRushConfigurationJson => {
   return JsonFile.load(getRushConfigurationJsonPath(rootPath));
 };
-export const loadRushSubspacesConfiguration = (
-  rootPath: string = getRootPath()
-): ISubspacesConfigurationJson => {
+export const loadRushSubspacesConfiguration = (rootPath: string): ISubspacesConfigurationJson => {
   return JsonFile.load(getRushSubspacesConfigurationJsonPath(rootPath));
 };
 
-export const querySubspaces = (rootPath: string = getRootPath()): string[] => {
+export const querySubspaces = (rootPath: string): string[] => {
   const subspaceJson: ISubspacesConfigurationJson = loadRushSubspacesConfiguration(rootPath);
   return subspaceJson.subspaceNames;
 };
 
-export const isExternalMonorepo = (
-  sourceRootPath: string,
-  targetRootPath: string = getRootPath()
-): boolean => {
+export const isExternalMonorepo = (sourceRootPath: string, targetRootPath: string): boolean => {
   return sourceRootPath !== targetRootPath;
 };

--- a/rush-plugins/rush-migrate-subspace-plugin/src/utilities/subspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/utilities/subspace.ts
@@ -1,7 +1,6 @@
 import { FileSystem, IPackageJsonDependencyTable, JsonFile } from '@rushstack/node-core-library';
 import { RushNameConstants, RushPathConstants } from '../constants/paths';
 import { ISubspacesConfigurationJson } from '@rushstack/rush-sdk/lib/api/SubspacesConfiguration';
-import { getRootPath } from './path';
 import {
   getRushConfigurationJsonPath,
   getRushSubspacesConfigurationJsonPath,
@@ -18,7 +17,7 @@ import { getProjectDependencies } from './project';
 
 export const queryProjectsFromSubspace = (
   targetSubspaceName: string,
-  rootPath: string = getRootPath()
+  rootPath: string
 ): IRushConfigurationProjectJson[] => {
   const rushConfig: IRushConfigurationJson = loadRushConfiguration(rootPath);
   return rushConfig.projects.filter(({ subspaceName }) => subspaceName === targetSubspaceName);
@@ -27,14 +26,14 @@ export const queryProjectsFromSubspace = (
 const getRushLegacySubspaceConfigurationFolderPath = (
   subspaceName: string,
   projectFolderPath: string,
-  rootPath: string = getRootPath()
+  rootPath: string
 ): string => {
   return `${rootPath}/${projectFolderPath}/subspace/${subspaceName}`;
 };
 
 export const getRushSubspaceConfigurationFolderPath = (
   subspaceName: string,
-  rootPath: string = getRootPath(),
+  rootPath: string,
   projectFolderPath?: string
 ): string => {
   if (projectFolderPath) {
@@ -52,10 +51,7 @@ export const getRushSubspaceConfigurationFolderPath = (
   return `${rootPath}/${RushPathConstants.SubspacesConfigurationFolderPath}/${subspaceName}`;
 };
 
-export const getRushSubspaceCommonVersionsFilePath = (
-  subspaceName: string,
-  rootPath: string = getRootPath()
-): string => {
+export const getRushSubspaceCommonVersionsFilePath = (subspaceName: string, rootPath: string): string => {
   return `${getRushSubspaceConfigurationFolderPath(subspaceName, rootPath)}/${
     RushConstants.commonVersionsFilename
   }`;
@@ -63,15 +59,12 @@ export const getRushSubspaceCommonVersionsFilePath = (
 
 export const loadRushSubspaceCommonVersions = (
   subspaceName: string,
-  rootPath: string = getRootPath()
+  rootPath: string
 ): RushSubspaceCommonVersionsJson => {
   return JsonFile.load(getRushSubspaceCommonVersionsFilePath(subspaceName, rootPath));
 };
 
-export const getRushSubspacePnpmFilePath = (
-  subspaceName: string,
-  rootPath: string = getRootPath()
-): string => {
+export const getRushSubspacePnpmFilePath = (subspaceName: string, rootPath: string): string => {
   return `${getRushSubspaceConfigurationFolderPath(subspaceName, rootPath)}/${
     RushNameConstants.PnpmSubspaceFileName
   }`;
@@ -79,15 +72,12 @@ export const getRushSubspacePnpmFilePath = (
 
 export const loadRushSubspacePnpm = (
   subspaceName: string,
-  rootPath: string = getRootPath()
+  rootPath: string
 ): RushSubspaceCommonVersionsJson => {
   return JsonFile.load(getRushSubspacePnpmFilePath(subspaceName, rootPath));
 };
 
-export const getRushSubspaceNpmRcFilePath = (
-  subspaceName: string,
-  rootPath: string = getRootPath()
-): string => {
+export const getRushSubspaceNpmRcFilePath = (subspaceName: string, rootPath: string): string => {
   return `${getRushSubspaceConfigurationFolderPath(subspaceName, rootPath)}/${
     RushNameConstants.NpmRcFileName
   }`;
@@ -95,31 +85,31 @@ export const getRushSubspaceNpmRcFilePath = (
 
 export const loadRushSubspaceNpmRc = (
   subspaceName: string,
-  rootPath: string = getRootPath()
+  rootPath: string
 ): RushSubspaceCommonVersionsJson => {
   return JsonFile.load(getRushSubspaceNpmRcFilePath(subspaceName, rootPath));
 };
 
-export const isSubspaceSupported = (rootPath: string = getRootPath()): boolean => {
+export const isSubspaceSupported = (rootPath: string): boolean => {
   if (
     FileSystem.exists(getRushSubspacesConfigurationJsonPath(rootPath)) &&
     FileSystem.exists(getRushSubspaceConfigurationFolderPath(RushConstants.defaultSubspaceName, rootPath))
   ) {
-    const subspacesConfig: ISubspacesConfigurationJson = loadRushSubspacesConfiguration();
+    const subspacesConfig: ISubspacesConfigurationJson = loadRushSubspacesConfiguration(rootPath);
     return subspacesConfig.subspacesEnabled;
   }
 
   return false;
 };
 
-export const subspaceExists = (subspaceName: string, rootPath: string = getRootPath()): boolean => {
+export const subspaceExists = (subspaceName: string, rootPath: string): boolean => {
   const subspaces: string[] = querySubspaces(rootPath);
   return !!subspaces.find((name) => name === subspaceName);
 };
 
 export const getSubspaceMismatches = (
   subspaceName: string,
-  rootPath: string = getRootPath()
+  rootPath: string
 ): ReadonlyMap<string, ReadonlyMap<string, readonly VersionMismatchFinderEntity[]>> => {
   const rushConfig: RushConfiguration = RushConfiguration.loadFromConfigurationFile(
     getRushConfigurationJsonPath(rootPath)
@@ -135,7 +125,7 @@ export const getSubspaceMismatches = (
 
 export const getSubspaceDependencies = (
   subspaceName: string,
-  rootPath: string = getRootPath()
+  rootPath: string
 ): Map<string, Map<string, string[]>> => {
   const subspaceProjects: IRushConfigurationProjectJson[] = queryProjectsFromSubspace(subspaceName, rootPath);
   const subspaceDependencies: Map<string, Map<string, string[]>> = new Map<string, Map<string, string[]>>();

--- a/rush-plugins/rush-migrate-subspace-plugin/src/utilities/subspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/utilities/subspace.ts
@@ -15,7 +15,6 @@ import { VersionMismatchFinder } from '@rushstack/rush-sdk/lib/logic/versionMism
 import { VersionMismatchFinderEntity } from '@rushstack/rush-sdk/lib/logic/versionMismatch/VersionMismatchFinderEntity';
 import { IRushConfigurationProjectJson } from '@rushstack/rush-sdk/lib/api/RushConfigurationProject';
 import { getProjectDependencies } from './project';
-import { sortVersions, subsetVersion } from './dependency';
 
 export const queryProjectsFromSubspace = (
   targetSubspaceName: string,
@@ -159,61 +158,4 @@ export const getSubspaceDependencies = (
   }
 
   return subspaceDependencies;
-};
-
-const reduceSubspaceDependencyVersions = (versions: string[]): string[] => {
-  const validVersions: string[] = sortVersions(versions);
-
-  let targetIndex: number = 0;
-  while (targetIndex < validVersions.length) {
-    const targetVersion: string = validVersions[targetIndex];
-    const toCompareVersions: string[] = validVersions.slice(targetIndex + 1);
-
-    const toDeleteIndex: number = toCompareVersions.findIndex((toCompareVersion) =>
-      subsetVersion(toCompareVersion, targetVersion)
-    );
-
-    if (toDeleteIndex > -1) {
-      validVersions.splice(targetIndex + 1 + toDeleteIndex, 1);
-    } else {
-      targetIndex += 1;
-    }
-  }
-
-  return validVersions;
-};
-
-export const cleanSubspaceCommonVersions = (
-  subspaceName: string,
-  rootPath: string = getRootPath()
-): boolean => {
-  let hasChanged: boolean = false;
-  const subspaceCommonVersionsPath: string = getRushSubspaceCommonVersionsFilePath(subspaceName, rootPath);
-  const subspaceCommonVersionsJson: RushSubspaceCommonVersionsJson = loadRushSubspaceCommonVersions(
-    subspaceName,
-    rootPath
-  );
-
-  subspaceCommonVersionsJson.allowedAlternativeVersions =
-    subspaceCommonVersionsJson.allowedAlternativeVersions || {};
-  for (const [dependency, versions] of Object.entries(
-    subspaceCommonVersionsJson.allowedAlternativeVersions
-  )) {
-    // Remove duplicates & unnecessary versions
-    const validVersions: string[] = reduceSubspaceDependencyVersions(versions);
-    if (validVersions.length === 0) {
-      delete subspaceCommonVersionsJson.allowedAlternativeVersions[dependency];
-    } else {
-      subspaceCommonVersionsJson.allowedAlternativeVersions[dependency] = validVersions;
-    }
-
-    hasChanged = hasChanged || validVersions.length !== versions.length;
-  }
-
-  if (hasChanged) {
-    JsonFile.save(subspaceCommonVersionsJson, subspaceCommonVersionsPath);
-    return true;
-  }
-
-  return false;
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

**Reason for adding this feature**

A lot of subspaces are not being properly managed, where there are a lot of similar, duplicated or unused dependency versions being added to the "common-versions.json". Adding this feature helps developers to rapidly clean their subspace multiple dependency versions, reducing its "pnpm-lock.yaml" file and minimise future issues.

**How to use**

```
rush migrate-subspace --clean
```

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

### Summary

Supports the parameter --clean, to remove a subspace unnecessary dependency versions, reducing its "pnpm-lock.yaml" file and prevent future dependency issues.

### Detail

- Removes duplicated dependency versions from "common-versions.json" alternativeAllowedVersions
- Removes unused dependency versions from "common-versions.json" alternativeAllowedVersions
- Removes duplicated dependency versions from "package.json" between devDependencies and dependencies
- Removes superset dependencies from "common-versions.json" alternativeAllowedVersions and updates each proper project "package.json" with the new subset version (e.g. Project P1 contains A@^1.0.0 and Project P2 contains A@1.0.1, the script will remove ^1.0.0 from the "common-versions.json" and update P1 "package.json" to A@1.0.1)