### PR TITLE
fix: updates properly project eden configurations

### DIFF
--- a/common/changes/rush-migrate-subspace-plugin/pedrogomes-fix-eden-logs_2024-12-17-16-31.json
+++ b/common/changes/rush-migrate-subspace-plugin/pedrogomes-fix-eden-logs_2024-12-17-16-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-migrate-subspace-plugin",
+      "comment": "Fixes debug logs during eden update",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-migrate-subspace-plugin"
+}

--- a/common/changes/rush-migrate-subspace-plugin/pedrogomes-fix-eden-logs_2024-12-17-17-08.json
+++ b/common/changes/rush-migrate-subspace-plugin/pedrogomes-fix-eden-logs_2024-12-17-17-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-migrate-subspace-plugin",
+      "comment": "Updates properly eden.pipeline and eden.monorepo files when project changes path",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-migrate-subspace-plugin"
+}

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
@@ -5,7 +5,6 @@ import Console from '../providers/console';
 import { Colorize } from '@rushstack/terminal';
 import { IRushConfigurationProjectJson } from '@rushstack/rush-sdk/lib/api/RushConfigurationProject';
 import { enterNewProjectLocationPrompt, moveProjectPrompt } from '../prompts/project';
-import { queryProject } from '../utilities/project';
 import { getRootPath } from '../utilities/path';
 import { RushConstants } from '@rushstack/rush-sdk';
 import { addProjectToRushConfiguration } from './updateRushConfiguration';
@@ -16,6 +15,7 @@ import {
 } from '../utilities/repository';
 import { ISubspacesConfigurationJson } from '@rushstack/rush-sdk/lib/api/SubspacesConfiguration';
 import { queryProjectsFromSubspace } from '../utilities/subspace';
+import path from 'path';
 
 const refreshSubspace = (subspaceName: string, rootPath: string): void => {
   const subspacesConfig: ISubspacesConfigurationJson = loadRushSubspacesConfiguration(rootPath);
@@ -88,10 +88,7 @@ export const addProjectToSubspace = async (
     }
 
     if (FileSystem.exists(`${getRootPath()}/${RushNameConstants.EdenMonorepoFileName}`)) {
-      const targetProject: IRushConfigurationProjectJson = queryProject(
-        sourceProject.packageName
-      ) as IRushConfigurationProjectJson;
-      await updateEdenProject(sourceProject, targetProject);
+      await updateEdenProject(sourceProject, path.relative(sourceMonorepoPath, targetProjectFolderPath));
     }
   }
 

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateEdenProject.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateEdenProject.ts
@@ -22,7 +22,7 @@ export async function updateEdenProject(
       );
 
       Console.debug(
-        `Updating ${Colorize.bold(edenPipelineJson)}, by adding ${Colorize.bold(
+        `Updating ${Colorize.bold(edenPipelineFilePath)}, by adding ${Colorize.bold(
           targetProject.packageName
         )} into pipeline path...`
       );
@@ -44,7 +44,7 @@ export async function updateEdenProject(
     edenProject.path = targetProject.projectFolder;
 
     Console.debug(
-      `Updating ${Colorize.bold(edenMonorepoJson)}, by adding ${Colorize.bold(
+      `Updating ${Colorize.bold(edenMonorepoFilePath)}, by adding ${Colorize.bold(
         targetProject.packageName
       )} into package path...`
     );

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateEdenProject.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateEdenProject.ts
@@ -7,23 +7,19 @@ import { getRootPath } from '../utilities/path';
 
 export async function updateEdenProject(
   sourceProject: IRushConfigurationProjectJson,
-  targetProject: IRushConfigurationProjectJson
+  targetProjectFolderPath: string
 ): Promise<void> {
   Console.debug(`Update monorepo eden configuration on ${Colorize.bold(getRootPath())}...`);
 
   const edenPipelineFilePath: string = `${getRootPath()}/${RushNameConstants.EdenPipelineFileName}`;
   const edenPipelineJson: JsonObject = JsonFile.load(edenPipelineFilePath);
   for (const entry of Object.values<JsonObject>(edenPipelineJson.scene.scm)) {
-    if (entry.entries[0] === targetProject.packageName && entry.pipelinePath) {
-      // Update the pipelinePath
-      entry.pipelinePath = entry.pipelinePath.replace(
-        sourceProject.projectFolder,
-        targetProject.projectFolder
-      );
+    if (entry.pipelinePath?.includes(sourceProject.projectFolder)) {
+      entry.pipelinePath = entry.pipelinePath.replace(sourceProject.projectFolder, targetProjectFolderPath);
 
       Console.debug(
         `Updating ${Colorize.bold(edenPipelineFilePath)}, by adding ${Colorize.bold(
-          targetProject.packageName
+          sourceProject.packageName
         )} into pipeline path...`
       );
       JsonFile.save(edenPipelineJson, edenPipelineFilePath, {
@@ -36,16 +32,16 @@ export async function updateEdenProject(
 
   const edenMonorepoFilePath: string = `${getRootPath()}/${RushNameConstants.EdenMonorepoFileName}`;
   const edenMonorepoJson: JsonObject = JsonFile.load(edenMonorepoFilePath);
-  const edenProject: JsonObject = edenMonorepoJson.packages.filter(
-    ({ name }: JsonObject) => name === targetProject.packageName
-  )[0];
+  const edenProject: JsonObject = edenMonorepoJson.packages.find(
+    ({ name }: JsonObject) => name === sourceProject.packageName
+  );
 
   if (edenProject) {
-    edenProject.path = targetProject.projectFolder;
+    edenProject.path = targetProjectFolderPath;
 
     Console.debug(
       `Updating ${Colorize.bold(edenMonorepoFilePath)}, by adding ${Colorize.bold(
-        targetProject.packageName
+        sourceProject.packageName
       )} into package path...`
     );
 

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/project.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/project.ts
@@ -1,6 +1,5 @@
 import inquirer from 'inquirer';
 import { basename } from 'path';
-import Console from '../providers/console';
 import { Colorize } from '@rushstack/terminal';
 
 export const moveProjectPrompt = async (): Promise<boolean> => {
@@ -22,7 +21,7 @@ export const enterNewProjectLocationPrompt = async (
   const defaultProjectName: string = basename(sourceProjectFolderPath);
   const { projectFolderName } = await inquirer.prompt([
     {
-      message: `Please enter the folder (or subfolder) you want to move this project to. ${Console.newLine()}${targetSubspaceFolderPath}/<your_project_folder>`,
+      message: `Please enter the folder (or subfolder) you want to move this project to. ${targetSubspaceFolderPath}/<your_project_folder>`,
       type: 'input',
       name: 'projectFolderName',
       default: defaultProjectName


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

### Summary

Updates properly project eden configurations, including properly printing debug logs.

### Detail

The debug log was printing the wrong variable: instead of the eden pipeline and eden monorepo file paths, it was printing their content, which is unintended.
At the same time, the eden.pipeline and eden.monorepo configuration files were not being correctly updated.

### How to test it

Run locally the subspace-migration, by moving the project configured as an eden project. 
