### PR TITLE
[rush-migrate-subspace-plugin]: support external repository subspace migration

### DIFF
--- a/common/changes/rush-migrate-subspace-plugin/pedrogomes-activate-external-repo_2025-01-31-10-37.json
+++ b/common/changes/rush-migrate-subspace-plugin/pedrogomes-activate-external-repo_2025-01-31-10-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-migrate-subspace-plugin",
+      "comment": "Supports external repository subspace migration",
+      "type": "minor"
+    }
+  ],
+  "packageName": "rush-migrate-subspace-plugin"
+}

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
@@ -27,17 +27,16 @@ program
     Console.title(`🚀 Rush Migrate Subspace Plugin - version ${packageJson.version}`);
     Console.newLine();
 
-    const sourceMonorepoPath: string = getRootPath();
     const targetMonorepoPath: string = getRootPath();
 
     if (sync) {
       await syncVersions(targetMonorepoPath);
     } else if (move) {
-      await migrateProject(sourceMonorepoPath, targetMonorepoPath);
+      await migrateProject(targetMonorepoPath);
     } else if (clean) {
       await cleanSubspace(targetMonorepoPath);
     } else {
-      await interactMenu(sourceMonorepoPath, targetMonorepoPath);
+      await interactMenu(targetMonorepoPath);
     }
   });
 

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
@@ -6,7 +6,7 @@ import { Colorize } from '@rushstack/terminal';
 import { IRushConfigurationProjectJson } from '@rushstack/rush-sdk/lib/api/RushConfigurationProject';
 import { enterNewProjectLocationPrompt, moveProjectPrompt } from '../prompts/project';
 import { RushConstants } from '@rushstack/rush-sdk';
-import { addProjectToRushConfiguration } from './updateRushConfiguration';
+import { addProjectToRushConfiguration, removeProjectFromRushConfiguration } from './updateRushConfiguration';
 import {
   getRushSubspacesConfigurationJsonPath,
   isExternalMonorepo,
@@ -73,7 +73,7 @@ export const addProjectToSubspace = async (
   targetMonorepoPath: string
 ): Promise<void> => {
   Console.debug(
-    `Adding project ${Colorize.bold(sourceProject.packageName)} to subspace ${Colorize.bold(
+    `Adding source project ${Colorize.bold(sourceProject.packageName)} to target subspace ${Colorize.bold(
       targetSubspace
     )}...`
   );
@@ -99,11 +99,6 @@ export const addProjectToSubspace = async (
     }
   }
 
-  /** WARN: Disabling different repositories for now.
-  addProjectToRushConfiguration(sourceProject, targetSubspace, targetProjectFolderPath);
-  removeProjectFromRushConfiguration(sourceProject, sourceMonorepoPath);
-   */
-
   const targetLegacySubspaceFolderPath: string = `${targetProjectFolderPath}/subspace`;
   if (FileSystem.exists(targetLegacySubspaceFolderPath)) {
     Console.debug(`Removing legacy subspace folder ${Colorize.bold(targetLegacySubspaceFolderPath)}...`);
@@ -111,13 +106,14 @@ export const addProjectToSubspace = async (
   }
 
   addProjectToRushConfiguration(sourceProject, targetSubspace, targetProjectFolderPath, targetMonorepoPath);
+  removeProjectFromRushConfiguration(sourceProject, sourceMonorepoPath);
   if (sourceProject.subspaceName) {
     refreshSubspace(sourceProject.subspaceName, sourceMonorepoPath);
   }
 
   Console.success(
-    `Project ${Colorize.bold(
+    `Source project ${Colorize.bold(
       sourceProject.packageName
-    )} has been successfully added to subspace ${Colorize.bold(targetSubspace)}.`
+    )} has been successfully added to target subspace ${Colorize.bold(targetSubspace)}.`
   );
 };

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateRushConfiguration.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/updateRushConfiguration.ts
@@ -19,7 +19,9 @@ export const removeProjectFromRushConfiguration = (
 
   if (projectIndex < 0) {
     Console.error(
-      `The project ${Colorize.bold(project.packageName)} wasn't found in ${RushConstants.rushJsonFilename}!`
+      `The source project ${Colorize.bold(project.packageName)} wasn't found in ${
+        RushConstants.rushJsonFilename
+      }!`
     );
     return;
   }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/interactMenu.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/interactMenu.ts
@@ -4,7 +4,7 @@ import { chooseCommandPrompt } from './prompts/command';
 import Console from './providers/console';
 import { syncVersions } from './syncVersions';
 
-export const interactMenu = async (sourceMonorepoPath: string, targetMonorepoPath: string): Promise<void> => {
+export const interactMenu = async (targetMonorepoPath: string): Promise<void> => {
   let exitApplication: boolean = false;
   do {
     const nextCommand: string = await chooseCommandPrompt();
@@ -14,7 +14,7 @@ export const interactMenu = async (sourceMonorepoPath: string, targetMonorepoPat
         break;
 
       case 'move':
-        await migrateProject(sourceMonorepoPath, targetMonorepoPath);
+        await migrateProject(targetMonorepoPath);
         Console.newLine();
         break;
 

--- a/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
@@ -14,24 +14,12 @@ import {
 } from './utilities/repository';
 import { RushConstants } from '@rushstack/rush-sdk';
 import { syncProjectMismatchedDependencies } from './functions/syncProjectDependencies';
+import { chooseRepositoryPrompt } from './prompts/repository';
 
-export const migrateProject = async (
-  sourceMonorepoPath: string,
-  targetMonorepoPath: string
-): Promise<void> => {
+export const migrateProject = async (targetMonorepoPath: string): Promise<void> => {
   Console.debug('Executing project migration command...');
 
   Console.title(`🔍 Analyzing if monorepo ${Colorize.underline(targetMonorepoPath)} supports subspaces...`);
-
-  /**
-   * WARN: Disabling auto subspace initialization for now.
-   * if (!isSubspaceSupported()) {
-   *     Console.warn(
-   *  `The monorepo ${Colorize.bold(rootPath)} doesn't contain subspaces. Initializing subspaces...`
-   *);
-   * await initSubspaces();
-   * }
-   */
 
   const targetSubspaces: string[] = querySubspaces(targetMonorepoPath);
   if (!isSubspaceSupported(targetMonorepoPath) || targetSubspaces.length === 0) {
@@ -49,27 +37,12 @@ export const migrateProject = async (
 
   Console.title(`🔍 Finding projects to migrate to ${Colorize.bold(targetMonorepoPath)}...`);
 
-  /**
-   * WARN: Disabling different repository selection for now.
-   * const sourceMonorepoPath: string = await chooseRepositoryPrompt();
-   * Console.warn(
-   *   `The script will migrate from ${Colorize.bold(sourceMonorepoPath)} to ${Colorize.bold(getRootPath())}`
-   * );
-   */
-
-  /**
-   * WARN: Disabling creating new subspaces for now.
-   *   const subspaceSelectionType: string = await chooseCreateOrSelectSubspacePrompt(targetSubspaces);
-   *
-   * const targetSubspace: string =
-   *  subspaceSelectionType === 'new'
-   *    ? await createSubspacePrompt(targetSubspaces)
-   *    : await chooseSubspacePrompt(targetSubspaces);
-   *
-   * if (!targetSubspaces.includes(targetSubspace)) {
-   *  await createSubspace(targetSubspace);
-   *}
-   */
+  const sourceMonorepoPath: string = await chooseRepositoryPrompt();
+  Console.warn(
+    `The script will migrate from ${Colorize.bold(sourceMonorepoPath)} to ${Colorize.bold(
+      targetMonorepoPath
+    )}`
+  );
 
   const targetSubspace: string = await chooseSubspacePrompt(targetSubspaces);
 

--- a/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/migrateProject.ts
@@ -74,7 +74,7 @@ export const migrateProject = async (targetMonorepoPath: string): Promise<void> 
     }
 
     Console.title(
-      `🏃 Migrating project ${sourceProjectToMigrate.packageName} to subspace ${targetSubspace}...`
+      `🏃 Migrating source project ${sourceProjectToMigrate.packageName} to target subspace ${targetSubspace}...`
     );
 
     if (sourceProjectToMigrate.subspaceName) {

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/project.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/project.ts
@@ -34,7 +34,7 @@ export const enterNewProjectLocationPrompt = async (
 export const chooseProjectPrompt = async (projects: string[]): Promise<string> => {
   const { projectName } = await inquirer.prompt([
     {
-      message: `Please select the project name (Type to filter).`,
+      message: `Please select the source project name (Type to filter).`,
       type: 'search-list',
       name: 'projectName',
       choices: projects.sort().map((name) => ({ name, value: name }))

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/repository.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/repository.ts
@@ -5,7 +5,7 @@ import { FileSystem } from '@rushstack/node-core-library';
 export const chooseRepositoryPrompt = async (): Promise<string> => {
   const { repoPathInput } = await inquirer.prompt([
     {
-      message: 'Please enter the repository root path.',
+      message: 'Please enter the source repository root path.',
       type: 'input',
       name: 'repoPathInput',
       default: getRootPath(),

--- a/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/prompts/subspace.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer';
 export const chooseSubspacePrompt = async (subspaces: string[]): Promise<string> => {
   const { subspaceNameInput } = await inquirer.prompt([
     {
-      message: 'Please select the subspace name (Type to filter).',
+      message: 'Please select the target subspace name (Type to filter).',
       type: 'search-list',
       name: 'subspaceNameInput',
       choices: subspaces.sort().map((name) => ({ name, value: name }))


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

**Reason for adding this feature**

Most of TikTok projects need to be migrated to a new repository.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Support external repository subspace migration.

### Detail

When running subspace migration phase, developers will be able to move projects from repository A to repository B.

### How to test it

Run and follow the steps:

```
rush migrate-subspace --move
```

![CleanShot 2025-01-31 at 18 42 40@2x](https://github.com/user-attachments/assets/ddf2eeff-55af-4ca9-b05f-7449ebdf29c0)
