### PR TITLE
[rush-migrate-subspace-plugin] Fix remove project from rush.json

### DIFF
--- a/common/changes/rush-migrate-subspace-plugin/pedrogomes-activate-external-repo_2025-02-12-06-40.json
+++ b/common/changes/rush-migrate-subspace-plugin/pedrogomes-activate-external-repo_2025-02-12-06-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-migrate-subspace-plugin",
+      "comment": "Fixes rush.json removing project",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-migrate-subspace-plugin"
+}

--- a/rush-plugins/rush-migrate-subspace-plugin/command-line.json
+++ b/rush-plugins/rush-migrate-subspace-plugin/command-line.json
@@ -25,7 +25,7 @@
     },
     {
       "parameterKind": "flag",
-      "longName": "--debug",
+      "longName": "--debug-logs",
       "description": "Provide debug logs",
       "associatedCommands": ["migrate-subspace"]
     },

--- a/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/cli.ts
@@ -18,9 +18,9 @@ program
   .option('--sync', 'to sync the versions in a subspace')
   .option('--move', 'to move projects to a new subspace')
   .option('--clean', 'to reduce subspace alternative versions')
-  .option('--debug', 'to provide debug logs')
-  .description('Example: rush migrate-subspace [--move] [--sync] [--debug] [--clean]')
-  .action(async ({ sync, debug, move, clean }) => {
+  .option('--debug-logs', 'to provide debug logs')
+  .description('Example: rush migrate-subspace [--move] [--sync] [--debug-logs] [--clean]')
+  .action(async ({ sync, debugLogs: debug, move, clean }) => {
     const packageJson: IPackageJson = JsonFile.load(`${path.resolve(__dirname, '../package.json')}`);
 
     Console.enableDebug(debug);

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
@@ -79,7 +79,8 @@ export const addProjectToSubspace = async (
   );
 
   let targetProjectFolderPath: string | undefined = `${targetMonorepoPath}/${sourceProject.projectFolder}`;
-  if (isExternalMonorepo(sourceMonorepoPath, targetMonorepoPath) || (await moveProjectPrompt())) {
+  const isExternal = isExternalMonorepo(sourceMonorepoPath, targetMonorepoPath);
+  if (isExternal || (await moveProjectPrompt())) {
     const sourceProjectFolderPath: string = `${sourceMonorepoPath}/${sourceProject.projectFolder}`;
     targetProjectFolderPath = await moveProjectToSubspaceFolder(
       sourceProjectFolderPath,
@@ -106,7 +107,10 @@ export const addProjectToSubspace = async (
   }
 
   addProjectToRushConfiguration(sourceProject, targetSubspace, targetProjectFolderPath, targetMonorepoPath);
-  removeProjectFromRushConfiguration(sourceProject, sourceMonorepoPath);
+  if (isExternal) {
+    removeProjectFromRushConfiguration(sourceProject, sourceMonorepoPath);
+  }
+
   if (sourceProject.subspaceName) {
     refreshSubspace(sourceProject.subspaceName, sourceMonorepoPath);
   }

--- a/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
+++ b/rush-plugins/rush-migrate-subspace-plugin/src/functions/addProjectToSubspace.ts
@@ -79,7 +79,7 @@ export const addProjectToSubspace = async (
   );
 
   let targetProjectFolderPath: string | undefined = `${targetMonorepoPath}/${sourceProject.projectFolder}`;
-  const isExternal = isExternalMonorepo(sourceMonorepoPath, targetMonorepoPath);
+  const isExternal: boolean = isExternalMonorepo(sourceMonorepoPath, targetMonorepoPath);
   if (isExternal || (await moveProjectPrompt())) {
     const sourceProjectFolderPath: string = `${sourceMonorepoPath}/${sourceProject.projectFolder}`;
     targetProjectFolderPath = await moveProjectToSubspaceFolder(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Fixes rush.json removing project

### Detail

When the source monorepo is the same as the target, the script will remove the project from rush.json, which is not correct.

### How to test it

Manual testing
